### PR TITLE
Adição de retorno dos registros dos usuários temporários e limpeza da tabela.

### DIFF
--- a/src/main/java/com/zlologin/zlologin/config/SecurityConfig.java
+++ b/src/main/java/com/zlologin/zlologin/config/SecurityConfig.java
@@ -42,6 +42,9 @@ public class SecurityConfig {
                         // Apenas usuários com a role "RESPONSAVEL" podem acessar os endpoints /api/responsavel/**
                         .requestMatchers("/api/responsavel/**").hasRole("RESPONSAVEL")
 
+                        // Apenas ADMIN pode apagar registros
+                        .requestMatchers("/temp-users").hasRole("ADMIN")
+
                         // ADMIN pode acessar todos os endpoints
                         .requestMatchers("/admin/**", "/api/**").hasRole("ADMIN")
 

--- a/src/main/java/com/zlologin/zlologin/controller/TempUserController.java
+++ b/src/main/java/com/zlologin/zlologin/controller/TempUserController.java
@@ -1,0 +1,36 @@
+package com.zlologin.zlologin.controller;
+
+import com.zlologin.zlologin.model.TempUser;
+import com.zlologin.zlologin.repository.TempUserRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class TempUserController {
+
+    private final TempUserRepository tempUserRepository;
+
+    public TempUserController(TempUserRepository tempUserRepository) {
+        this.tempUserRepository = tempUserRepository;
+    }
+
+    // Endpoint 1: Retorna todos os registros da tabela temp_users
+    @GetMapping("/temp-users")
+    public ResponseEntity<List<TempUser>> getAllTempUsers() {
+        List<TempUser> tempUsers = tempUserRepository.findAll();
+        return ResponseEntity.ok(tempUsers);
+    }
+
+    // Endpoint 2: Limpa todos os registros da tabela temp_users
+    @DeleteMapping("/temp-users")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<String> deleteAllTempUsers() {
+        tempUserRepository.deleteAll();
+        return ResponseEntity.ok("Todos os registros de usuários temporários foram removidos com sucesso.");
+    }
+}

--- a/src/test/java/com/zlologin/zlologin/controller/TempUserControllerTest.java
+++ b/src/test/java/com/zlologin/zlologin/controller/TempUserControllerTest.java
@@ -1,0 +1,76 @@
+package com.zlologin.zlologin.controller;
+
+import com.zlologin.zlologin.model.TempUser;
+import com.zlologin.zlologin.repository.TempUserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class TempUserControllerTest {
+
+    @InjectMocks
+    private TempUserController tempUserController;
+
+    @Mock
+    private TempUserRepository tempUserRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getAllTempUsers_ShouldReturnListOfTempUsers() {
+        // Arrange
+        List<TempUser> mockUsers = new ArrayList<>();
+        mockUsers.add(new TempUser(1L, "user1@example.com", "555199999999", "token1",
+                LocalDateTime.now(), LocalDateTime.now().plusMinutes(15), "ROLE_TEMPUSER"));
+        mockUsers.add(new TempUser(2L, "user2@example.com", "555199999998", "token2",
+                LocalDateTime.now(), LocalDateTime.now().plusMinutes(15), "ROLE_TEMPUSER"));
+
+        when(tempUserRepository.findAll()).thenReturn(mockUsers);
+
+        // Act
+        ResponseEntity<List<TempUser>> response = tempUserController.getAllTempUsers();
+
+        // Assert
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(2, response.getBody().size());
+        verify(tempUserRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getAllTempUsers_ShouldReturnEmptyList_WhenNoTempUsersExist() {
+        // Arrange
+        when(tempUserRepository.findAll()).thenReturn(new ArrayList<>());
+
+        // Act
+        ResponseEntity<List<TempUser>> response = tempUserController.getAllTempUsers();
+
+        // Assert
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(0, response.getBody().size());
+        verify(tempUserRepository, times(1)).findAll();
+    }
+
+    @Test
+    void deleteAllTempUsers_ShouldDeleteAllUsers_WhenRoleIsAdmin() {
+        // Act
+        ResponseEntity<String> response = tempUserController.deleteAllTempUsers();
+
+        // Assert
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals("Todos os registros de usuários temporários foram removidos com sucesso.", response.getBody());
+        verify(tempUserRepository, times(1)).deleteAll();
+    }
+}


### PR DESCRIPTION
Nessa task, foram implementados dois novos endpoints:

1. Retorno dos registros da tabela temp_users que armazena os dados de criação dos usuário temporários.
2. Limpeza/exclusão dos registros da tabela temp_users.

Importante ressaltar que esses endpoints, diferentes dos que possuem sub caminho de /auth, só são permitidos serem utilizados com o token de autenticação JWT sendo a ROLE do usuário do tipo "ROLE_ADMIN", visando garantir a segurança na operação dos endpoints, por serem operações críticas no que diz a qualquer usuário.